### PR TITLE
Add role-based permission checks

### DIFF
--- a/label_studio/core/api_permissions.py
+++ b/label_studio/core/api_permissions.py
@@ -1,5 +1,8 @@
 from rest_framework.permissions import SAFE_METHODS, BasePermission
 
+from organizations.models import Organization
+from projects.models import Project
+
 
 class HasObjectPermission(BasePermission):
     def has_object_permission(self, request, view, obj):
@@ -12,3 +15,99 @@ class MemberHasOwnerPermission(BasePermission):
             return False
 
         return obj.has_permission(request.user)
+
+
+class RolePermission(BasePermission):
+    """Role based permission for organization and project level operations.
+
+    Views using this permission should define ``required_roles`` attribute with
+    allowed roles for organization and/or project levels, for example::
+
+        required_roles = {
+            'organization': ['owner'],
+            'project': ['owner', 'member'],
+        }
+
+    ``organization`` and ``project`` keys are optional. If ``required_roles`` is
+    missing the check is skipped.
+    """
+
+    def has_permission(self, request, view):  # type: ignore[override]
+        roles = getattr(view, 'required_roles', None)
+        return self._check_roles(request, view, roles)
+
+    def has_object_permission(self, request, view, obj):  # type: ignore[override]
+        roles = getattr(view, 'required_roles', None)
+        return self._check_roles(request, view, roles, obj=obj)
+
+    def _check_roles(self, request, view, roles, obj=None):
+        if not roles:
+            return True
+
+        user = request.user
+
+        if roles.get('organization'):
+            organization = self._get_organization(request, view, obj)
+            if organization is None:
+                return False
+            org_role = self._get_organization_role(user, organization)
+            if org_role not in roles['organization']:
+                return False
+
+        if roles.get('project'):
+            project = self._get_project(request, view, obj)
+            if project is None:
+                return False
+            project_role = self._get_project_role(user, project)
+            if project_role not in roles['project']:
+                return False
+
+        return True
+
+    def _get_organization(self, request, view, obj):
+        if isinstance(obj, Organization):
+            return obj
+        if isinstance(obj, Project):
+            return obj.organization
+        if hasattr(obj, 'organization'):
+            return obj.organization
+
+        org_pk = view.kwargs.get('pk') or view.kwargs.get('organization_pk') or view.kwargs.get('id')
+        if org_pk:
+            try:
+                return Organization.objects.get(pk=org_pk)
+            except Organization.DoesNotExist:
+                return None
+
+        return request.user.active_organization
+
+    def _get_project(self, request, view, obj):
+        if isinstance(obj, Project):
+            return obj
+        if hasattr(obj, 'project'):
+            return obj.project
+
+        project_pk = view.kwargs.get('pk') or view.kwargs.get('project_pk') or view.kwargs.get('id')
+        if project_pk:
+            try:
+                return Project.objects.get(pk=project_pk)
+            except Project.DoesNotExist:
+                return None
+
+        return None
+
+    @staticmethod
+    def _get_organization_role(user, organization):
+        if organization.created_by_id == user.id:
+            return 'owner'
+        if organization.has_user(user):
+            return 'member'
+        return 'none'
+
+    @staticmethod
+    def _get_project_role(user, project):
+        if project.created_by_id == user.id:
+            return 'owner'
+        if project.members.filter(user=user, enabled=True).exists():
+            return 'member'
+        return 'none'

--- a/label_studio/organizations/api.py
+++ b/label_studio/organizations/api.py
@@ -33,6 +33,7 @@ from tasks.models import Annotation
 from users.models import User
 
 from label_studio.core.permissions import ViewClassPermission, all_permissions
+from label_studio.core.api_permissions import RolePermission
 from label_studio.core.utils.params import bool_from_request
 
 logger = logging.getLogger(__name__)
@@ -252,12 +253,13 @@ class OrganizationMemberDetailAPI(GetParentObjectMixin, generics.RetrieveDestroy
     parser_classes = (JSONParser, FormParser, MultiPartParser)
     serializer_class = OrganizationMemberSerializer
     http_method_names = ['delete', 'get']
+    required_roles = {'organization': ['owner']}
 
     @property
     def permission_classes(self):
         if self.request.method == 'DELETE':
-            return [IsAuthenticated, HasObjectPermission]
-        return api_settings.DEFAULT_PERMISSION_CLASSES
+            return [IsAuthenticated, HasObjectPermission, RolePermission]
+        return api_settings.DEFAULT_PERMISSION_CLASSES + [RolePermission]
 
     def get_queryset(self):
         return OrganizationMember.objects.filter(organization=self.parent_object)
@@ -325,6 +327,8 @@ class OrganizationAPI(generics.RetrieveUpdateAPIView):
     queryset = Organization.objects.all()
     permission_required = all_permissions.organizations_change
     serializer_class = OrganizationSerializer
+    permission_classes = api_settings.DEFAULT_PERMISSION_CLASSES + [RolePermission]
+    required_roles = {'organization': ['owner']}
 
     redirect_route = 'organizations-dashboard'
     redirect_kwarg = 'pk'

--- a/label_studio/projects/api.py
+++ b/label_studio/projects/api.py
@@ -8,6 +8,7 @@ from core.filters import ListFilter
 from core.label_config import config_essential_data_has_changed
 from core.mixins import GetParentObjectMixin
 from core.permissions import ViewClassPermission, all_permissions
+from core.api_permissions import RolePermission
 from core.redis import start_job_async_or_sync
 from core.utils.common import paginator, paginator_help, temporary_disconnect_all_signals
 from core.utils.exceptions import LabelStudioDatabaseException, ProjectExistException
@@ -622,6 +623,8 @@ class ProjectSummaryResetAPI(GetParentObjectMixin, generics.CreateAPIView):
     permission_required = ViewClassPermission(
         POST=all_permissions.projects_change,
     )
+    permission_classes = api_settings.DEFAULT_PERMISSION_CLASSES + [RolePermission]
+    required_roles = {'project': ['owner']}
 
     @extend_schema(exclude=True)
     def post(self, *args, **kwargs):
@@ -659,11 +662,12 @@ class ProjectSummaryResetAPI(GetParentObjectMixin, generics.CreateAPIView):
 )
 class ProjectImportAPI(generics.RetrieveAPIView):
     permission_required = all_permissions.projects_change
-    permission_classes = api_settings.DEFAULT_PERMISSION_CLASSES + [ProjectImportPermission]
+    permission_classes = api_settings.DEFAULT_PERMISSION_CLASSES + [ProjectImportPermission, RolePermission]
     parser_classes = (JSONParser,)
     serializer_class = ProjectImportSerializer
     queryset = ProjectImport.objects.all()
     lookup_url_kwarg = 'import_pk'
+    required_roles = {'project': ['owner']}
 
 
 @method_decorator(
@@ -687,11 +691,12 @@ class ProjectImportAPI(generics.RetrieveAPIView):
 )
 class ProjectReimportAPI(generics.RetrieveAPIView):
     permission_required = all_permissions.projects_change
-    permission_classes = api_settings.DEFAULT_PERMISSION_CLASSES + [ProjectImportPermission]
+    permission_classes = api_settings.DEFAULT_PERMISSION_CLASSES + [ProjectImportPermission, RolePermission]
     parser_classes = (JSONParser,)
     serializer_class = ProjectReimportSerializer
     queryset = ProjectReimport.objects.all()
     lookup_url_kwarg = 'reimport_pk'
+    required_roles = {'project': ['owner']}
 
 
 @method_decorator(


### PR DESCRIPTION
## Summary
- add generic RolePermission that validates organization and project roles
- enforce RolePermission on project import/reset endpoints
- enforce RolePermission on organization member and settings endpoints

## Testing
- `PYTHONPATH=$PWD pytest label_studio/core/tests label_studio/organizations/tests/test_api.py::TestOrganizationMemberListAPI::test_list_organization_members -q` *(fails: ImportError: label-studio)*

------
https://chatgpt.com/codex/tasks/task_e_68b31c9bd6ac83269e21b59c94a6c33e