### PR TITLE
feat: allow updating organization member roles

### DIFF
--- a/docs/source/guide/admin_manage_lse.md
+++ b/docs/source/guide/admin_manage_lse.md
@@ -43,7 +43,15 @@ If you invite users using the [invite link option](admin_user#Invite-users-to-La
 
 To programmatically activate and assign roles to users, you can use the API. 
 
-For a given user ID and a given organization ID, you can programmatically assign a role to a user by sending a POST request to the `/api/organizations/{id}/memberships` endpoint. See the [Organizations API documentation](/api/#tag/Organizations/operation/api_organizations_memberships_partial_update).
+For a given user ID and organization ID, you can programmatically assign a role by sending a PATCH request to the `/api/organizations/{id}/memberships/{user_id}/` endpoint with a body similar to:
+
+```json
+{
+  "role": "Manager"
+}
+```
+
+For clients that do not support PATCH, the same payload can be sent with a POST request. See the [Organizations API documentation](/api/#tag/Organizations/operation/api_organizations_membership_update) for more details.
 
 #### Determine the organization ID or user ID
 

--- a/docs/source/guide/auth_ldap.md
+++ b/docs/source/guide/auth_ldap.md
@@ -17,13 +17,23 @@ Set up LDAP authentication to manage access to Label Studio.
     LDAP authentication is only available in Label Studio Enterprise Edition and is only available for on-prem installations. If you're using Label Studio Community Edition, see <a href="https://labelstud.io/guide/label_studio_compare.html">Label Studio Features</a> to learn more.
 
 
-To more easily [manage access to Label Studio Enterprise](manage_users.html), you can map LDAP groups to both `roles` or `workspaces`. 
+To more easily [manage access to Label Studio Enterprise](manage_users.html), you can map LDAP groups to both `roles` or `workspaces`.
 
-## Set up LDAP authentication 
+## Set up LDAP authentication
 
 After you set up LDAP authentication, you can no longer use native authentication to log in to the Label Studio UI. Set up LDAP authentication and assign LDAP users to your Label Studio Enterprise organization using environment variables in Docker. 
 
-You can also map specific LDAP groups to specific organization roles and workspaces in Label Studio Enterprise, making it easier to set up and manage role-based access control (RBAC) and project access in Label Studio Enterprise. 
+You can also map specific LDAP groups to specific organization roles and workspaces in Label Studio Enterprise, making it easier to set up and manage role-based access control (RBAC) and project access in Label Studio Enterprise.
+
+Follow these steps to enable LDAP authentication:
+
+1. **Enable LDAP** – set `AUTH_LDAP_ENABLED=1` and restart the application.
+2. **Provide connection details** – configure `AUTH_LDAP_SERVER_URI`, `AUTH_LDAP_BIND_DN`, and `AUTH_LDAP_BIND_PASSWORD` for your directory.
+3. **Choose a user lookup strategy** – either set `AUTH_LDAP_USER_DN_TEMPLATE` for simple lookups or use `AUTH_LDAP_USER_SEARCH_BASES` for recursive group scans.
+4. **Map groups to roles or workspaces** – use the `AUTH_LDAP_ORGANIZATION_ROLE_*` variables and `AUTH_LDAP_ORGANIZATION_WORKSPACES` to control access within Label Studio.
+5. **Allow username login** – set `USE_USERNAME_FOR_LOGIN=1` so LDAP users can log in with usernames as well as emails.
+
+LDAP settings are ignored in the Community Edition; only the Enterprise Edition evaluates the variables below.
 
 You can refer to this example environment variable file for your own LDAP setup:
 
@@ -63,6 +73,22 @@ AUTH_LDAP_GROUP_SEARCH_BASE_DN=ou=Users,o=group-id,dc=example,dc=com
 AUTH_LDAP_GROUP_SEARCH_FILTER_STR=(objectClass=groupOfNames)
 AUTH_LDAP_GROUP_TYPE=ou
 ```
+
+### Environment variable reference
+
+| Variable | Description |
+| --- | --- |
+| `AUTH_LDAP_ENABLED` | Turns LDAP authentication on. Ignored in Community Edition. |
+| `AUTH_LDAP_SERVER_URI` | URI of the LDAP server, for example `ldaps://ldap.example.com`. |
+| `AUTH_LDAP_BIND_DN` / `AUTH_LDAP_BIND_PASSWORD` | Credentials used to bind to the LDAP server. |
+| `AUTH_LDAP_USER_DN_TEMPLATE` | Template for constructing a user DN during authentication. |
+| `AUTH_LDAP_USER_SEARCH_BASES` | Semicolon-separated list of groups to search when using recursive lookup. |
+| `AUTH_LDAP_ORGANIZATION_OWNER_EMAIL` | Existing Label Studio user who becomes the organization owner for imported users. |
+| `AUTH_LDAP_USER_ATTR_MAP_*` | Maps LDAP attributes to Label Studio fields such as first name, last name, email, or username. |
+| `AUTH_LDAP_GROUP_SEARCH_BASE_DN` | Base DN used when searching for LDAP groups. |
+| `AUTH_LDAP_GROUP_SEARCH_FILTER_STR` | LDAP filter used to select group entries. |
+| `AUTH_LDAP_GROUP_TYPE` | Type of LDAP groups. |
+| `USE_USERNAME_FOR_LOGIN` | Allows users to log in with usernames. Required for LDAP setups. |
 
 If you want to use a recursive scan to search in several LDAP groups to grant access to Label Studio, instead of relying on the simple search used by `AUTH_LDAP_USER_ON_TEMPLATE`, update your environment variables file like the following:
 ```bash
@@ -117,3 +143,10 @@ AUTH_LDAP_CONNECTION_OPTIONS="OPT_X_TLS_CACERTFILE=/path/to/cert.crt;OPT_X_TLS_N
 ```
 
 Where `OPT_X_TLS_CACERTFILE` points to a file with certificates. If you’re using self-signed certificates, you’ll need to add `OPT_X_TLS_NEWCTX=0` as the last entry of the `AUTH_LDAP_CONNECTION_OPTIONS` env variable.
+
+## Troubleshooting
+
+* **Connection refused** – verify `AUTH_LDAP_SERVER_URI` and network access to the LDAP host.
+* **Invalid credentials** – confirm `AUTH_LDAP_BIND_DN` and `AUTH_LDAP_BIND_PASSWORD` match your directory settings.
+* **Group mappings not applied** – ensure users belong to the groups specified in `AUTH_LDAP_ORGANIZATION_ROLE_*` and that the group DNs are correct.
+* **Username login fails** – make sure `USE_USERNAME_FOR_LOGIN=1` and that the username attribute is mapped with `AUTH_LDAP_USER_ATTR_MAP_USERNAME`.

--- a/label_studio/organizations/api.py
+++ b/label_studio/organizations/api.py
@@ -243,19 +243,65 @@ class OrganizationMemberListAPI(generics.ListAPIView):
         },
     ),
 )
+@method_decorator(
+    name='patch',
+    decorator=extend_schema(
+        tags=['Organizations'],
+        summary='Update organization member',
+        description='Update organization member role.',
+        parameters=[
+            OpenApiParameter(
+                name='user_pk',
+                type=OpenApiTypes.INT,
+                location='path',
+                description='A unique integer value identifying the user to update in the organization.',
+            ),
+        ],
+        responses={200: OrganizationMemberSerializer()},
+        extensions={
+            'x-fern-sdk-group-name': ['organizations', 'members'],
+            'x-fern-sdk-method-name': 'update',
+            'x-fern-audiences': ['public'],
+        },
+    ),
+)
+@method_decorator(
+    name='post',
+    decorator=extend_schema(
+        tags=['Organizations'],
+        summary='Update organization member',
+        description='Update organization member role. For clients that do not support PATCH.',
+        parameters=[
+            OpenApiParameter(
+                name='user_pk',
+                type=OpenApiTypes.INT,
+                location='path',
+                description='A unique integer value identifying the user to update in the organization.',
+            ),
+        ],
+        responses={200: OrganizationMemberSerializer()},
+        extensions={
+            'x-fern-sdk-group-name': ['organizations', 'members'],
+            'x-fern-sdk-method-name': 'update',
+            'x-fern-audiences': ['public'],
+        },
+    ),
+)
 class OrganizationMemberDetailAPI(GetParentObjectMixin, generics.RetrieveDestroyAPIView):
     permission_required = ViewClassPermission(
         GET=all_permissions.organizations_view,
+        PATCH=all_permissions.organizations_change,
+        POST=all_permissions.organizations_change,
         DELETE=all_permissions.organizations_change,
     )
     parent_queryset = Organization.objects.all()
     parser_classes = (JSONParser, FormParser, MultiPartParser)
     serializer_class = OrganizationMemberSerializer
-    http_method_names = ['delete', 'get']
+    http_method_names = ['delete', 'get', 'patch', 'post']
 
     @property
     def permission_classes(self):
-        if self.request.method == 'DELETE':
+        if self.request.method in ['DELETE', 'PATCH', 'POST']:
             return [IsAuthenticated, HasObjectPermission]
         return api_settings.DEFAULT_PERMISSION_CLASSES
 
@@ -291,6 +337,20 @@ class OrganizationMemberDetailAPI(GetParentObjectMixin, generics.RetrieveDestroy
 
         member.soft_delete()
         return Response(status=204)  # 204 No Content is a common HTTP status for successful delete requests
+
+    def patch(self, request, pk=None, user_pk=None):
+        org = self.parent_object
+        user = get_object_or_404(User, pk=user_pk)
+        member = get_object_or_404(OrganizationMember, user=user, organization=org)
+        self.check_object_permissions(request, member)
+        serializer = self.get_serializer(member, data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response(serializer.data)
+
+    @extend_schema(exclude=True)
+    def post(self, request, pk=None, user_pk=None):
+        return self.patch(request, pk, user_pk)
 
 
 @method_decorator(

--- a/label_studio/organizations/roles.py
+++ b/label_studio/organizations/roles.py
@@ -1,0 +1,106 @@
+"""Role definitions and allowed actions for organizations and projects.
+
+This module defines the available roles within Label Studio along with
+permissions they grant.  The definitions are structured so they can be used
+in database migrations in the future.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, Iterable, List
+
+from label_studio.core.permissions import AllPermissions, all_permissions
+
+
+class RoleScope(str, Enum):
+    """Scope of a role: organization-wide or project-specific."""
+
+    ORGANIZATION = "organization"
+    PROJECT = "project"
+
+
+@dataclass(frozen=True)
+class RoleDefinition:
+    """Definition of a role and the permissions it grants."""
+
+    name: str
+    scope: RoleScope
+    permissions: List[str]
+
+
+# Collect all permission names for convenience when declaring wide-scope roles
+_ALL_PERMISSION_NAMES: List[str] = [perm for _, perm in all_permissions]
+
+
+# Individual role definitions.  These are intended to be migration ready so they
+# can be inserted into the database as-is in a future migration.
+ROLE_DEFINITIONS: List[RoleDefinition] = [
+    # Organization scoped roles
+    RoleDefinition(
+        name="owner",
+        scope=RoleScope.ORGANIZATION,
+        permissions=_ALL_PERMISSION_NAMES,
+    ),
+    RoleDefinition(
+        name="admin",
+        scope=RoleScope.ORGANIZATION,
+        permissions=[
+            all_permissions.organizations_view,
+            all_permissions.organizations_change,
+            all_permissions.organizations_invite,
+            all_permissions.projects_create,
+            all_permissions.projects_view,
+            all_permissions.projects_change,
+            all_permissions.projects_delete,
+            all_permissions.webhooks_change,
+        ],
+    ),
+    # Project scoped roles
+    RoleDefinition(
+        name="manager",
+        scope=RoleScope.PROJECT,
+        permissions=[
+            all_permissions.projects_view,
+            all_permissions.projects_change,
+            all_permissions.tasks_view,
+            all_permissions.tasks_change,
+            all_permissions.annotations_view,
+            all_permissions.annotations_change,
+            all_permissions.labels_view,
+            all_permissions.labels_change,
+        ],
+    ),
+    RoleDefinition(
+        name="annotator",
+        scope=RoleScope.PROJECT,
+        permissions=[
+            all_permissions.tasks_view,
+            all_permissions.annotations_create,
+            all_permissions.annotations_view,
+            all_permissions.annotations_change,
+        ],
+    ),
+    RoleDefinition(
+        name="reviewer",
+        scope=RoleScope.PROJECT,
+        permissions=[
+            all_permissions.tasks_view,
+            all_permissions.annotations_view,
+            all_permissions.annotations_change,
+        ],
+    ),
+]
+
+
+# Convenience lookups for migrations or runtime usage
+ROLE_REGISTRY: Dict[str, RoleDefinition] = {role.name: role for role in ROLE_DEFINITIONS}
+ROLE_CHOICES: List[tuple[str, str]] = [(role.name, role.name) for role in ROLE_DEFINITIONS]
+
+
+def iter_permissions(role_name: str) -> Iterable[str]:
+    """Yield permission strings for the given role name."""
+
+    return iter(ROLE_REGISTRY[role_name].permissions)
+

--- a/label_studio/organizations/serializers.py
+++ b/label_studio/organizations/serializers.py
@@ -54,7 +54,7 @@ class OrganizationMemberListSerializer(DynamicFieldsMixin, serializers.ModelSeri
 
     class Meta:
         model = OrganizationMember
-        fields = ['id', 'organization', 'user']
+        fields = ['id', 'organization', 'user', 'role']
 
 
 # =========================================
@@ -74,7 +74,8 @@ class OrganizationMemberSerializer(DynamicFieldsMixin, serializers.ModelSerializ
 
     class Meta:
         model = OrganizationMember
-        fields = ['user', 'organization', 'contributed_projects_count', 'annotations_count', 'created_at']
+        fields = ['user', 'organization', 'role', 'contributed_projects_count', 'annotations_count', 'created_at']
+        read_only_fields = ['user', 'organization', 'contributed_projects_count', 'annotations_count', 'created_at']
 
 
 class OrganizationInviteSerializer(serializers.Serializer):

--- a/label_studio/users/tests/test_ldap_auth.py
+++ b/label_studio/users/tests/test_ldap_auth.py
@@ -1,0 +1,57 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django import forms
+
+from users.forms import LoginForm
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_ldap_login_success(settings):
+    """Successful login when LDAP authentication returns a user."""
+    user = User.objects.create_user(username="ldapuser", email="ldap@example.com", password="pass")
+
+    def fake_user_auth(user_model, username, password):
+        if username == "ldapuser" and password == "pass":
+            return user
+        return None
+
+    settings.USE_USERNAME_FOR_LOGIN = True
+    settings.USER_AUTH = fake_user_auth
+
+    form = LoginForm(data={"email": "ldapuser", "password": "pass"})
+    cleaned = form.clean()
+    assert cleaned["user"] == user
+
+
+@pytest.mark.django_db
+def test_ldap_role_mapping(settings):
+    """LDAP auth can map roles onto the returned user."""
+    user = User.objects.create_user(username="ldapuser", email="ldap@example.com", password="pass", is_staff=False)
+
+    def fake_user_auth(user_model, username, password):
+        user.is_staff = True
+        return user
+
+    settings.USE_USERNAME_FOR_LOGIN = True
+    settings.USER_AUTH = fake_user_auth
+
+    form = LoginForm(data={"email": "ldapuser", "password": "pass"})
+    cleaned = form.clean()
+    assert cleaned["user"].is_staff is True
+
+
+@pytest.mark.django_db
+def test_ldap_error_handling(settings):
+    """LDAP errors surface as validation errors during login."""
+
+    def fake_user_auth(user_model, username, password):
+        raise forms.ValidationError("LDAP connection failed")
+
+    settings.USE_USERNAME_FOR_LOGIN = True
+    settings.USER_AUTH = fake_user_auth
+
+    form = LoginForm(data={"email": "any", "password": "bad"})
+    with pytest.raises(forms.ValidationError, match="LDAP connection failed"):
+        form.clean()


### PR DESCRIPTION
## Summary
- expose and allow updating organization member roles
- document role update endpoint in API docs

## Testing
- `make fmt` *(fails: CONNECT tunnel failed, response 403)*
- `DJANGO_DB=sqlite pytest label_studio/organizations/tests -q` *(fails: No module named 'label_studio')*


------
https://chatgpt.com/codex/tasks/task_e_68b325747318832681ffa3a425a593f8