### PR TITLE
feat: add RBAC tests and docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,21 @@ When submitting pull requests for code changes, please use the following standar
 - For documentation pull requests, verify that the change is correctly rendered in the automatically generated preview.
 - Label Studio backend code should be compatible with sqlite and postgresql databases. Our automated tests will run against both sqlite and postgresql-equipped environments, but please use database backend specific features with care.
 
+
+### Migrations and setup
+
+Run database migrations and collect static files before starting the server or running tests:
+
+```bash
+python label_studio/manage.py migrate
+python label_studio/manage.py collectstatic
+```
+
+If you modify models, create new migrations with:
+
+```bash
+python label_studio/manage.py makemigrations
+```
 ### Additional questions
 
 If you have any questions that aren't answered in these guidelines, please find us in the #contributor channel of the [Label Studio Slack Community](https://slack.labelstud.io/?source=github-contrib).

--- a/docs/source/guide/rbac.md
+++ b/docs/source/guide/rbac.md
@@ -1,0 +1,31 @@
+# Role-Based Access Control
+
+Label Studio uses role-based access control (RBAC) to manage what each user can see and modify.
+
+## Roles
+
+- **Owner** – full control over the workspace and organization settings.
+- **Administrator** – manage members and configure projects.
+- **Manager** – create projects and manage labeling tasks.
+- **Reviewer** – review and approve completed annotations.
+- **Annotator** – label data assigned to them.
+
+## Permissions
+
+Common permissions include:
+
+- `organizations.view` – read organization details.
+- `organizations.change` – update organization settings or membership.
+- `projects.create` – create new projects.
+- `projects.view` – view project data.
+
+## Example Usage
+
+An annotator can list organization members but cannot delete another member. A DELETE request to the memberships endpoint returns **403 Forbidden** for unauthorized roles:
+
+```http
+DELETE /api/organizations/{org_id}/memberships/{user_id}/
+# -> 403 Forbidden
+```
+
+Use roles and permissions to limit access to critical actions and keep your workspace secure.

--- a/label_studio/__init__.py
+++ b/label_studio/__init__.py
@@ -6,7 +6,10 @@ import importlib.metadata
 package_name = 'label-studio'
 
 # Package version
-__version__ = importlib.metadata.metadata(package_name).get('version')
+try:
+    __version__ = importlib.metadata.metadata(package_name).get('version')
+except importlib.metadata.PackageNotFoundError:
+    __version__ = '0.0.0'
 
 # pypi info
 __latest_version__ = None

--- a/label_studio/core/utils/common.py
+++ b/label_studio/core/utils/common.py
@@ -366,7 +366,10 @@ def retry_database_locked():
 
 
 def get_app_version():
-    return importlib.metadata.version('label-studio')
+    try:
+        return importlib.metadata.version('label-studio')
+    except importlib.metadata.PackageNotFoundError:
+        return '0.0.0'
 
 
 def get_latest_version():

--- a/label_studio/organizations/tests/conftest.py
+++ b/label_studio/organizations/tests/conftest.py
@@ -1,0 +1,13 @@
+import importlib.metadata
+
+
+class _Meta:
+    def get(self, key, default=None):
+        return '0.0.0'
+
+
+try:
+    importlib.metadata.metadata('label-studio')
+except importlib.metadata.PackageNotFoundError:
+    importlib.metadata.metadata = lambda name: _Meta()
+    importlib.metadata.version = lambda name: '0.0.0'

--- a/label_studio/organizations/tests/test_permissions.py
+++ b/label_studio/organizations/tests/test_permissions.py
@@ -1,0 +1,30 @@
+from organizations.tests.factories import OrganizationFactory
+from rest_framework.test import APITestCase
+from users.tests.factories import UserFactory
+
+
+class TestOrganizationPermissions(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.organization = OrganizationFactory(created_by__username='owner')
+        cls.owner = cls.organization.created_by
+        cls.member = UserFactory(username='member', active_organization=cls.organization)
+        cls.outsider_org = OrganizationFactory()
+        cls.outsider = UserFactory(username='outsider', active_organization=cls.outsider_org)
+        cls.target = UserFactory(username='target', active_organization=cls.organization)
+
+    def membership_url(self, user_id):
+        return f'/api/organizations/{self.organization.id}/memberships/{user_id}/'
+
+    def organization_url(self):
+        return f'/api/organizations/{self.organization.id}'
+
+    def test_non_owner_cannot_delete_member(self):
+        self.client.force_authenticate(user=self.member)
+        response = self.client.delete(self.membership_url(self.target.id))
+        assert response.status_code == 403
+
+    def test_outsider_cannot_update_organization(self):
+        self.client.force_authenticate(user=self.outsider)
+        response = self.client.patch(self.organization_url(), {'title': 'new title'}, format='json')
+        assert response.status_code == 403


### PR DESCRIPTION
## Summary
- add tests rejecting unauthorized member actions
- document Label Studio RBAC roles and permissions
- outline migration and setup commands for contributors
- handle missing package metadata gracefully

## Testing
- `PYTHONPATH=. DJANGO_DB=sqlite DJANGO_SETTINGS_MODULE=core.settings.label_studio pytest -q label_studio/organizations/tests`


------
https://chatgpt.com/codex/tasks/task_e_68b325771dd883269184e107d37206d1