### PR TITLE
Add LDAP backend configuration

### DIFF
--- a/label_studio/core/settings/base.py
+++ b/label_studio/core/settings/base.py
@@ -78,6 +78,7 @@ if not logging.getLogger().hasHandlers():
 
 from label_studio.core.utils.io import get_data_dir
 from label_studio.core.utils.params import get_bool_env, get_env
+from label_studio.core.settings import ldap as ldap_settings
 
 logger = logging.getLogger(__name__)
 SILENCED_SYSTEM_CHECKS = []
@@ -296,10 +297,18 @@ ALLOWED_HOSTS = get_env_list('ALLOWED_HOSTS', default=['*'])
 
 # Auth modules
 AUTH_USER_MODEL = 'users.User'
+AUTH_LDAP_ENABLED = ldap_settings.AUTH_LDAP_ENABLED
+AUTH_LDAP_SERVER_URI = ldap_settings.AUTH_LDAP_SERVER_URI
+AUTH_LDAP_BIND_DN = ldap_settings.AUTH_LDAP_BIND_DN
+AUTH_LDAP_BIND_PASSWORD = ldap_settings.AUTH_LDAP_BIND_PASSWORD
+AUTH_LDAP_CONNECTION_OPTIONS = ldap_settings.AUTH_LDAP_CONNECTION_OPTIONS
+
 AUTHENTICATION_BACKENDS = [
     'rules.permissions.ObjectPermissionBackend',
     'django.contrib.auth.backends.ModelBackend',
 ]
+if AUTH_LDAP_ENABLED:
+    AUTHENTICATION_BACKENDS.append('django_auth_ldap.backend.LDAPBackend')
 USE_USERNAME_FOR_LOGIN = False
 
 DISABLE_SIGNUP_WITHOUT_LINK = get_bool_env('DISABLE_SIGNUP_WITHOUT_LINK', False)

--- a/label_studio/core/settings/ldap.py
+++ b/label_studio/core/settings/ldap.py
@@ -1,0 +1,29 @@
+"""This file and its contents are licensed under the Apache License 2.0. Please see the included NOTICE for copyright information and LICENSE for a copy of the license."""
+
+import logging
+from label_studio.core.utils.params import get_env, get_bool_env
+
+logger = logging.getLogger(__name__)
+
+AUTH_LDAP_ENABLED = get_bool_env('AUTH_LDAP_ENABLED', False)
+AUTH_LDAP_SERVER_URI = get_env('AUTH_LDAP_SERVER_URI', '')
+AUTH_LDAP_BIND_DN = get_env('AUTH_LDAP_BIND_DN', '')
+AUTH_LDAP_BIND_PASSWORD = get_env('AUTH_LDAP_BIND_PASSWORD', '')
+
+AUTH_LDAP_CONNECTION_OPTIONS = {}
+raw_options = get_env('AUTH_LDAP_CONNECTION_OPTIONS', '')
+if raw_options:
+    try:
+        import ldap  # type: ignore
+        for option in raw_options.split(';'):
+            if not option:
+                continue
+            key, value = option.split('=', 1)
+            ldap_key = getattr(ldap, key, key)
+            try:
+                value = int(value)
+            except ValueError:
+                pass
+            AUTH_LDAP_CONNECTION_OPTIONS[ldap_key] = value
+    except Exception:
+        logger.exception('Failed to parse AUTH_LDAP_CONNECTION_OPTIONS')


### PR DESCRIPTION
## Summary
- support LDAP authentication via env-configured LDAP server credentials
- load LDAP-related environment variables in dedicated settings module

## Testing
- `pre-commit run --files label_studio/core/settings/base.py label_studio/core/settings/ldap.py` *(fails: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags') return code: 128)*
- `PYTHONPATH=. DJANGO_DB=sqlite pytest -v -m "not integration_tests" -c label_studio/pytest.ini label_studio/tests` *(fails: ImportError: label-studio)*

------
https://chatgpt.com/codex/tasks/task_e_68b32f090b7483268731a4653d023adf